### PR TITLE
Update main.css

### DIFF
--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -397,7 +397,7 @@ hr {
   }
 }
 
-#announcements {
+#announcements, .about {
 	width: 75%;
 }
 


### PR DESCRIPTION
Makes `.about` the same width as `#announcements` so the zoom doesn't make `.about` extend beyond the page bounds